### PR TITLE
Add region support

### DIFF
--- a/src/oms/core/types.ts
+++ b/src/oms/core/types.ts
@@ -27,6 +27,7 @@ export class AuthOptions {
  */
 export class CloudConfig {
     auth: AuthOptions
+    region?: string
 
     constructor() {
         this.auth = new (AuthOptions)()
@@ -39,36 +40,46 @@ export class CloudConfig {
 export class CloudConfigHelper {
     authUrl: string
 
-    constructor(authUrl: string) {
-        this.authUrl = authUrl
+    private readonly cfg: CloudConfig
+
+    get config(): CloudConfig {
+        return this.cfg
     }
 
-    baseCfg(): CloudConfig {
+    constructor(authUrl: string) {
+        this.authUrl = authUrl
+        this.cfg = this.baseCfg()
+    }
+
+    private baseCfg(): CloudConfig {
         const cc = new (CloudConfig)()
         cc.auth.auth_url = this.authUrl
         return cc
     }
 
-    withPassword(domainName: string, username: string, password: string, projectName: string): CloudConfig {
-        const cc = this.baseCfg()
-        cc.auth.domain_name = domainName
-        cc.auth.username = username
-        cc.auth.password = password
-        cc.auth.project_name = projectName
-        return cc
+    withRegion(region: string): CloudConfigHelper {
+        this.config.region = region
+        return this
     }
 
-    withToken(token: string): CloudConfig {
-        const cc = this.baseCfg()
-        cc.auth.token = token
-        return cc
+    withPassword(domainName: string, username: string, password: string, projectName: string): CloudConfigHelper {
+        this.config.auth.domain_name = domainName
+        this.config.auth.username = username
+        this.config.auth.password = password
+        this.config.auth.project_name = projectName
+        return this
     }
 
-    withAKSK(ak: string, sk: string): CloudConfig {
-        const cc = this.baseCfg()
-        cc.auth.ak = ak
-        cc.auth.sk = sk
-        return cc
+    withToken(token: string): CloudConfigHelper {
+        this.config.auth.token = token
+        return this
+    }
+
+    withAKSK(ak: string, sk: string, projectName?: string): CloudConfigHelper {
+        this.config.auth.ak = ak
+        this.config.auth.sk = sk
+        this.config.auth.project_name = projectName
+        return this
     }
 }
 

--- a/tests/functional/client.test.ts
+++ b/tests/functional/client.test.ts
@@ -2,8 +2,7 @@
 /**
  * @jest-environment node
  */
-import { Client } from '../../src/oms'
-import { CloudConfigHelper } from '../../src/oms/core'
+import { Client, cloudConfig } from '../../src/oms'
 import { IdentityV3 } from '../../src/oms/services/identity/v3'
 import { ImageV2 } from '../../src/oms/services/image'
 import Service from '../../src/oms/services/base'
@@ -15,16 +14,19 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const config = new CloudConfigHelper(authUrl).withToken(t)
+const config = cloudConfig(authUrl).withToken(t).config
 jest.setTimeout(1000000)
 
 test('Client_auth', async () => {
-    const client = new Client(config!)
+    const client = new Client(config)
     await client.authenticate()
+    expect(client.tokenID).toBeTruthy()
+    expect(client.domainID).toBeTruthy()
+    expect(client.projectID).toBeTruthy()
 })
 
 test('Client_serviceCatalog', async () => {
-    const client = new Client(config!)
+    const client = new Client(config)
     await client.authenticate()
     const iam = client.getService(IdentityV3)
     expect(iam.client.baseConfig.baseURL).toContain('iam.')
@@ -42,7 +44,7 @@ class PseudoIam extends Service {
 
 
 test('Client_invalidService', async () => {
-    const client = new Client(config!)
+    const client = new Client(config)
     await client.authenticate()
     expect(() => client.getService(PseudoIam)).toThrow(`Service '${PseudoIam.type}' is not registered`)
 })

--- a/tests/functional/services/compute.test.ts
+++ b/tests/functional/services/compute.test.ts
@@ -1,9 +1,9 @@
-import { CloudConfig, CloudConfigHelper } from '../../../src/oms/core'
+import { cloudConfig, CloudConfig } from '../../../src/oms/core'
 import { Client } from '../../../src/oms'
 import { ComputeV1, ComputeV2 } from '../../../src/oms/services/compute'
 
-let defaultConfig: CloudConfig
-let defaultClient: Client
+let config: CloudConfig
+let client: Client
 
 const authUrl = 'https://iam.eu-de.otc.t-systems.com/v3'
 
@@ -14,13 +14,13 @@ beforeAll(async () => {
     if (!t) {
         throw 'Missing OS_TOKEN required for tests'
     }
-    defaultConfig = new CloudConfigHelper(authUrl).withToken(t)
-    defaultClient = new Client(defaultConfig)
-    await defaultClient.authenticate()
+    config = cloudConfig(authUrl).withToken(t).config
+    client = new Client(config)
+    await client.authenticate()
 })
 
 test('Nova: list key pairs', async () => {
-    const nova = defaultClient.getService(ComputeV2)
+    const nova = client.getService(ComputeV2)
     const keyPairs = await nova.listKeyPairs()
     expect(keyPairs.length).toBeTruthy()
     expect(keyPairs[0]).toHaveProperty('name')
@@ -29,7 +29,7 @@ test('Nova: list key pairs', async () => {
 })
 
 test('ECS: list flavors', async () => {
-    const ecs = defaultClient.getService(ComputeV1)
+    const ecs = client.getService(ComputeV1)
     const all = await ecs.listFlavors()
     expect(all).toBeDefined()
     expect(all[0]).toHaveProperty('id')

--- a/tests/functional/services/identity.test.ts
+++ b/tests/functional/services/identity.test.ts
@@ -7,7 +7,7 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const config = cloudConfig(authUrl).withToken(t)
+const config = cloudConfig(authUrl).withToken(t).config
 const client = new Client(config)
 
 

--- a/tests/functional/services/image.test.ts
+++ b/tests/functional/services/image.test.ts
@@ -7,7 +7,7 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const defaultConfig = cloudConfig(authUrl).withToken(t)
+const defaultConfig = cloudConfig(authUrl).withToken(t).config
 const defaultClient = new Client(defaultConfig)
 
 jest.setTimeout(1000000)  // for debug

--- a/tests/functional/services/networkv1.test.ts
+++ b/tests/functional/services/networkv1.test.ts
@@ -9,7 +9,7 @@ if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
 const authUrl = 'https://iam.eu-de.otc.t-systems.com/v3'
-const config = cloudConfig(authUrl).withToken(t)
+const config = cloudConfig(authUrl).withToken(t).config
 const client = new Client(config)
 
 const orphans: {

--- a/tests/integration/client.test.ts
+++ b/tests/integration/client.test.ts
@@ -18,12 +18,15 @@ afterAll(() => {
 test.skip('Client: authToken', async () => {
     const cfg = cloudConfig(authServerUrl())
         .withPassword('MYDOMAIN', 'MYNAME', '>>>Super!Secret<<<', fakeRegion)
+        .config
     const client = new Client(cfg)
     await client.authToken()
 })
 
 test('Client: authAKSK', async () => {
-    const cfg = cloudConfig(authServerUrl()).withAKSK('AK', 'SK')
+    const cfg = cloudConfig(authServerUrl())
+        .withAKSK('AK', 'SK')
+        .config
     const client = new Client(cfg)
     await client.authAkSk()
 })
@@ -35,7 +38,9 @@ const srv = {
 }
 
 test('Client: register service', () => {
-    const cfg = cloudConfig(authServerUrl()).withToken(fakeToken)
+    const cfg = cloudConfig(authServerUrl())
+        .withToken(fakeToken)
+        .config
     const client = new Client(cfg)
     client.registerService(srv.type, srv.url)
 
@@ -56,6 +61,7 @@ test('Client: register service', () => {
 test.skip('Client: get not registered service', async () => {
     const cfg = cloudConfig(authServerUrl())
         .withPassword('MYDOMAIN', 'MYNAME', '>>>Super!Secret<<<', fakeRegion)
+        .config
     const client = new Client(cfg)
     await client.authenticate()
 
@@ -84,10 +90,9 @@ test('Client: no ak/sk opts', async () => {
 })
 
 test('Client: ak/sk opts', async () => {
-    const cfg = cloudConfig('http://nsdfdf').withAKSK(
-        randomString(10),
-        randomString(20),
-    )
+    const cfg = cloudConfig('http://nsdfdf')
+        .withAKSK(randomString(10),randomString(20))
+        .config
     const client = new Client(cfg)
     client.authAkSk = jest.fn()
     client.saveServiceCatalog = jest.fn()
@@ -96,19 +101,20 @@ test('Client: ak/sk opts', async () => {
 })
 
 test('Client: abs URL', async () => {
-    const cfg = cloudConfig(authServerUrl()).withToken('')
+    const cfg = cloudConfig(authServerUrl()).config
     const client = new Client(cfg)
     await client.httpClient.get({ url: authServerUrl() })
 })
 
 test('Client: abs URL with base', async () => {
-    const cfg = cloudConfig(authServerUrl()).withToken('')
+    const cfg = cloudConfig(authServerUrl())
+        .config
     const client = new Client(cfg)
     await client.httpClient.get({ url: authServerUrl(), baseURL: 'https://google.com' })
 })
 
 test('Client: merge handlers', async () => {
-    const cfg = cloudConfig(authServerUrl()).withToken('')
+    const cfg = cloudConfig(authServerUrl()).config
     const client = new Client(cfg)
     const mock1 = jest.fn()
     const mock2 = jest.fn()

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -1,11 +1,11 @@
 /// <reference types="jest" />
-import { CloudConfigHelper } from '../../src/oms/core/types';
-import { randomString } from '../utils/helpers';
+import { cloudConfig } from '../../src/oms/core'
+import { randomString } from '../utils/helpers'
 
 test('CloudConfigHelper_basic', () => {
     const authUrl = randomString(5)
-    const cc = new CloudConfigHelper(authUrl)
-    const auth = cc.baseCfg().auth
+    const cc = cloudConfig(authUrl)
+    const auth = cc.config.auth
     expect(auth.auth_url).toEqual(authUrl)
     expect(auth.token).toBeUndefined()
     expect(auth.username).toBeUndefined()
@@ -17,12 +17,12 @@ test('CloudConfigHelper_basic', () => {
 })
 
 test('CloudConfigHelper_pwd', () => {
-    const cc = new CloudConfigHelper('')
+    const cc = cloudConfig('')
     const domain = randomString(3)
     const username = randomString(3)
     const password = randomString(3)
     const project = randomString(3)
-    const auth = cc.withPassword(domain, username, password, project).auth
+    const auth = cc.withPassword(domain, username, password, project).config.auth
     expect(auth.token).toBeUndefined()
     expect(auth.username).toEqual(username)
     expect(auth.password).toEqual(password)
@@ -33,17 +33,36 @@ test('CloudConfigHelper_pwd', () => {
 })
 
 test('CloudConfigHelper_token', () => {
-    const cc = new CloudConfigHelper('')
+    const cc = cloudConfig('')
     const token = randomString(10)
-    const auth = cc.withToken(token).auth
+    const auth = cc.withToken(token).config.auth
     expect(auth.token).toEqual(token)
 })
 
+test('CloudConfigHelper_region', () => {
+    const cc = cloudConfig('')
+    const reg = randomString(4)
+    const cfg = cc.withRegion(reg).config
+    expect(cfg.region).toEqual(reg)
+})
+
 test('CloudConfigHelper_ak/sk', () => {
-    const cc = new CloudConfigHelper('')
+    const cc = cloudConfig('')
     const ak = randomString(5)
     const sk = randomString(10)
-    const auth = cc.withAKSK(ak, sk).auth
+    const auth = cc.withAKSK(ak, sk).config.auth
     expect(auth.ak).toEqual(ak)
     expect(auth.sk).toEqual(sk)
+})
+
+test('CloudConfigHelper_appending', () => {
+    const cc = cloudConfig('')
+    const reg = randomString(4)
+    const token = randomString(10)
+    const cfg = cc
+        .withRegion(reg)
+        .withToken(token)
+        .config
+    expect(cfg.region).toEqual(reg)
+    expect(cfg.auth.token).toEqual(token)
 })


### PR DESCRIPTION
* Add region to `CloudConfig`

* Replace `Client.authOptions` with `Client.cloud`

* Refactor `CloudConfigHelper`:
  Make methods chaining
  Add `withRegion`
  Make `withAKSK` to accept `projectName`