### PR TITLE
Refactor config helper

### DIFF
--- a/src/oms/core/types.ts
+++ b/src/oms/core/types.ts
@@ -9,7 +9,7 @@ export interface NameOrID {
  * Simple implementation of OpenStack auth options
  */
 export interface AuthOptions {
-    readonly auth_url: string
+    auth_url: string
     token?: string
     username?: string
     password?: string

--- a/src/oms/core/types.ts
+++ b/src/oms/core/types.ts
@@ -8,8 +8,8 @@ export interface NameOrID {
 /**
  * Simple implementation of OpenStack auth options
  */
-export class AuthOptions {
-    auth_url!: string
+export interface AuthOptions {
+    readonly auth_url: string
     token?: string
     username?: string
     password?: string
@@ -25,36 +25,19 @@ export class AuthOptions {
 /**
  * OpenTelekomCloud cloud configuration
  */
-export class CloudConfig {
+export interface CloudConfig {
     auth: AuthOptions
     region?: string
-
-    constructor() {
-        this.auth = new (AuthOptions)()
-    }
 }
 
 /**
  * CloudConfigHelper provides helper functions to get cloud configurations
  */
-export class CloudConfigHelper {
-    authUrl: string
-
-    private readonly cfg: CloudConfig
-
-    get config(): CloudConfig {
-        return this.cfg
-    }
+class CloudConfigHelper {
+    readonly config: CloudConfig
 
     constructor(authUrl: string) {
-        this.authUrl = authUrl
-        this.cfg = this.baseCfg()
-    }
-
-    private baseCfg(): CloudConfig {
-        const cc = new (CloudConfig)()
-        cc.auth.auth_url = this.authUrl
-        return cc
+        this.config = { auth: { auth_url: authUrl } }
     }
 
     withRegion(region: string): CloudConfigHelper {
@@ -62,11 +45,15 @@ export class CloudConfigHelper {
         return this
     }
 
-    withPassword(domainName: string, username: string, password: string, projectName: string): CloudConfigHelper {
+    withProject(projectName: string): CloudConfigHelper {
+        this.config.auth.project_name = projectName
+        return this
+    }
+
+    withPassword(domainName: string, username: string, password: string): CloudConfigHelper {
         this.config.auth.domain_name = domainName
         this.config.auth.username = username
         this.config.auth.password = password
-        this.config.auth.project_name = projectName
         return this
     }
 
@@ -75,15 +62,19 @@ export class CloudConfigHelper {
         return this
     }
 
-    withAKSK(ak: string, sk: string, projectName?: string): CloudConfigHelper {
+    withAKSK(ak: string, sk: string): CloudConfigHelper {
         this.config.auth.ak = ak
         this.config.auth.sk = sk
-        this.config.auth.project_name = projectName
         return this
     }
 }
 
-export function cloudConfig(authURL: string): CloudConfigHelper {
+/**
+ * Returns cloud configuration helper providing simple configuration
+ * generation witch chained methods
+ * @param authURL
+ */
+export function cloud(authURL: string): CloudConfigHelper {
     return new CloudConfigHelper(authURL)
 }
 

--- a/tests/functional/client.test.ts
+++ b/tests/functional/client.test.ts
@@ -2,7 +2,7 @@
 /**
  * @jest-environment node
  */
-import { Client, cloudConfig } from '../../src/oms'
+import { Client, cloud } from '../../src/oms'
 import { IdentityV3 } from '../../src/oms/services/identity/v3'
 import { ImageV2 } from '../../src/oms/services/image'
 import Service from '../../src/oms/services/base'
@@ -14,7 +14,7 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const config = cloudConfig(authUrl).withToken(t).config
+const config = cloud(authUrl).withToken(t).config
 jest.setTimeout(1000000)
 
 test('Client_auth', async () => {

--- a/tests/functional/client_ak_sk.test.ts
+++ b/tests/functional/client_ak_sk.test.ts
@@ -1,4 +1,4 @@
-import { cloudConfig } from '../../src/oms/core'
+import { cloud } from '../../src/oms/core'
 import { Client } from '../../src/oms'
 
 const authUrl = 'https://iam.eu-de.otc.t-systems.com'
@@ -12,8 +12,9 @@ if (!sk) {
 }
 
 test('Client: ak/sk auth', async () => {
-    const configAkSk = cloudConfig(authUrl)
-        .withAKSK(ak, sk, 'eu-de')
+    const configAkSk = cloud(authUrl)
+        .withAKSK(ak, sk)
+        .withProject('eu-de')
         .config
     const clientAkSk = new Client(configAkSk)
     await clientAkSk.authenticate()

--- a/tests/functional/services/compute.test.ts
+++ b/tests/functional/services/compute.test.ts
@@ -1,4 +1,4 @@
-import { cloudConfig, CloudConfig } from '../../../src/oms/core'
+import { cloud, CloudConfig } from '../../../src/oms/core'
 import { Client } from '../../../src/oms'
 import { ComputeV1, ComputeV2 } from '../../../src/oms/services/compute'
 
@@ -14,7 +14,7 @@ beforeAll(async () => {
     if (!t) {
         throw 'Missing OS_TOKEN required for tests'
     }
-    config = cloudConfig(authUrl).withToken(t).config
+    config = cloud(authUrl).withToken(t).config
     client = new Client(config)
     await client.authenticate()
 })

--- a/tests/functional/services/identity.test.ts
+++ b/tests/functional/services/identity.test.ts
@@ -1,4 +1,4 @@
-import { cloudConfig } from '../../../src/oms/core'
+import { cloud } from '../../../src/oms/core'
 import { Client } from '../../../src/oms'
 import { IdentityV3 } from '../../../src/oms/services/identity/v3'
 
@@ -9,7 +9,7 @@ test('Projects: list (token)', async () => {
     if (!t) {
         throw 'Missing OS_TOKEN required for tests'
     }
-    const config = cloudConfig(authUrl).withToken(t).config
+    const config = cloud(authUrl).withToken(t).config
     const client = new Client(config)
     await client.authenticate()
     const iam = client.getService(IdentityV3)
@@ -26,7 +26,7 @@ test('Projects: list (ak sk)', async () => {
     if (!sk) {
         throw 'Missing AWS_SECRET_ACCESS_KEY required for tests'
     }
-    const configAkSk = cloudConfig(authUrl).withAKSK(ak, sk).config
+    const configAkSk = cloud(authUrl).withAKSK(ak, sk).config
     const clientAkSk = new Client(configAkSk)
     await clientAkSk.authenticate()
     const iam = clientAkSk.getService(IdentityV3)

--- a/tests/functional/services/image.test.ts
+++ b/tests/functional/services/image.test.ts
@@ -1,5 +1,5 @@
 import { Client } from '../../../src/oms'
-import { cloudConfig } from '../../../src/oms/core'
+import { cloud } from '../../../src/oms/core'
 import { ImageV2 } from '../../../src/oms/services/image'
 
 const authUrl = 'https://iam.eu-de.otc.t-systems.com/v3'
@@ -7,7 +7,7 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const defaultConfig = cloudConfig(authUrl).withToken(t).config
+const defaultConfig = cloud(authUrl).withToken(t).config
 const defaultClient = new Client(defaultConfig)
 
 jest.setTimeout(1000000)  // for debug

--- a/tests/functional/services/networkv1.test.ts
+++ b/tests/functional/services/networkv1.test.ts
@@ -1,4 +1,4 @@
-import { cloudConfig } from '../../../src/oms/core'
+import { cloud } from '../../../src/oms/core'
 import { Client } from '../../../src/oms'
 import { VpcV1 } from '../../../src/oms/services/network'
 import { randomString } from '../../utils/helpers'
@@ -9,7 +9,7 @@ if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
 const authUrl = 'https://iam.eu-de.otc.t-systems.com/v3'
-const config = cloudConfig(authUrl).withToken(t).config
+const config = cloud(authUrl).withToken(t).config
 const client = new Client(config)
 
 const orphans: {

--- a/tests/functional/services/swift.test.ts
+++ b/tests/functional/services/swift.test.ts
@@ -1,4 +1,4 @@
-import { Client, cloudConfig, SwiftV1 } from '../../../src/oms'
+import { Client, cloud, SwiftV1 } from '../../../src/oms'
 import { randomString } from '../../utils/helpers'
 
 jest.setTimeout(10000)  // for debug
@@ -8,7 +8,7 @@ const t = process.env.OS_TOKEN
 if (!t) {
     throw 'Missing OS_TOKEN required for tests'
 }
-const config = cloudConfig(authUrl).withToken(t).config
+const config = cloud(authUrl).withToken(t).config
 const client = new Client(config)
 
 beforeAll(async () => {

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -1,5 +1,5 @@
 import HttpClient, { mergeHeaders, RequestOpts } from '../../src/oms/core/http'
-import { cloudConfig } from '../../src/oms/core'
+import { cloud } from '../../src/oms/core'
 import { Client } from '../../src/oms'
 
 import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock'
@@ -50,7 +50,7 @@ test('Client: header merging', () => {
 
 test('Client: required headers', async () => {
     const authUrl = 'https://google.com/'
-    const config = cloudConfig(authUrl).withToken('t').config
+    const config = cloud(authUrl).withToken('t').config
     const client = new Client(config)
     enableFetchMocks()
     fetchMock.mockOnce(async r => {

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -1,10 +1,10 @@
 /// <reference types="jest" />
-import { cloudConfig } from '../../src/oms/core'
+import { cloud } from '../../src/oms/core'
 import { randomString } from '../utils/helpers'
 
 test('CloudConfigHelper_basic', () => {
     const authUrl = randomString(5)
-    const cc = cloudConfig(authUrl)
+    const cc = cloud(authUrl)
     const auth = cc.config.auth
     expect(auth.auth_url).toEqual(authUrl)
     expect(auth.token).toBeUndefined()
@@ -17,12 +17,16 @@ test('CloudConfigHelper_basic', () => {
 })
 
 test('CloudConfigHelper_pwd', () => {
-    const cc = cloudConfig('')
+    const cc = cloud('')
     const domain = randomString(3)
     const username = randomString(3)
     const password = randomString(3)
     const project = randomString(3)
-    const auth = cc.withPassword(domain, username, password, project).config.auth
+    const auth = cc
+        .withPassword(domain, username, password)
+        .withProject(project)
+        .config
+        .auth
     expect(auth.token).toBeUndefined()
     expect(auth.username).toEqual(username)
     expect(auth.password).toEqual(password)
@@ -33,21 +37,21 @@ test('CloudConfigHelper_pwd', () => {
 })
 
 test('CloudConfigHelper_token', () => {
-    const cc = cloudConfig('')
+    const cc = cloud('')
     const token = randomString(10)
     const auth = cc.withToken(token).config.auth
     expect(auth.token).toEqual(token)
 })
 
 test('CloudConfigHelper_region', () => {
-    const cc = cloudConfig('')
+    const cc = cloud('')
     const reg = randomString(4)
     const cfg = cc.withRegion(reg).config
     expect(cfg.region).toEqual(reg)
 })
 
 test('CloudConfigHelper_ak/sk', () => {
-    const cc = cloudConfig('')
+    const cc = cloud('')
     const ak = randomString(5)
     const sk = randomString(10)
     const auth = cc.withAKSK(ak, sk).config.auth
@@ -56,7 +60,7 @@ test('CloudConfigHelper_ak/sk', () => {
 })
 
 test('CloudConfigHelper_appending', () => {
-    const cc = cloudConfig('')
+    const cc = cloud('')
     const reg = randomString(4)
     const token = randomString(10)
     const cfg = cc


### PR DESCRIPTION
Make `AuthOptions` and `CloudConfig` to be interfaces

Make `CloudConfigHelper` not exported

Move setting project name to `.withProject`

Rename `cloudConfig` function to `cloud`