### PR TITLE
Add possibility to receive non-JSON responses

### DIFF
--- a/tests/integration/client.test.ts
+++ b/tests/integration/client.test.ts
@@ -1,7 +1,7 @@
 import { cloud } from '../../src/oms/core'
 import { authServerUrl, fakeAuthServer, fakeServiceServer, fakeToken } from '../utils/servers'
 import { Client, IdentityV3 } from '../../src/oms'
-import { randomString } from '../utils/helpers'
+import { json, randomString } from '../utils/helpers'
 import Service from '../../src/oms/services/base'
 import HttpClient from '../../src/oms/core/http'
 import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock'
@@ -150,7 +150,7 @@ test('Client: ak/sk auth; request headers', async () => {
     const domainID = randomString(20)
     fetchMock.mockOnce(async req => {
         expect(req.url.endsWith(`?name=${projectName}`)).toBeTruthy()
-        return `{"projects": [{ "id": "${projectID}", "domain_id": "${domainID}" }]}`
+        return json(`{"projects": [{ "id": "${projectID}", "domain_id": "${domainID}" }]}`)
     })
     await clientAkSk.authenticate()
     fetchMock.mockOnce(async req => {
@@ -159,7 +159,7 @@ test('Client: ak/sk auth; request headers', async () => {
         expect(req.headers.get('x-project-id')).toBe(projectID)
         expect(req.headers.get('authorization')).toBeTruthy()
         expect(req.headers.get('authorization')?.startsWith('SDK-HMAC-SHA256 Credential=')).toBeTruthy()
-        return ''
+        return json()
     })
     const iam = clientAkSk.getService(IdentityV3)
     await iam.listProjects()

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -3,6 +3,7 @@ import { cloud } from '../../src/oms/core'
 import { Client } from '../../src/oms'
 
 import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock'
+import { json } from '../utils/helpers'
 
 test('RequestOpts: nothing', () => {
     expect(() => new RequestOpts({})).toThrowError(/^Request without Method.+/)
@@ -58,7 +59,7 @@ test('Client: required headers', async () => {
         expect(r.headers.get('Content-Type')).toBeDefined()
         expect(r.headers.get('Host')).toBeDefined()
         expect(r.headers.get('User-Agent')).toBeDefined()
-        return '{"token": {"user": {"domain": {"id": ""}}, "catalog": []}}'
+        return json('{"token": {"user": {"domain": {"id": ""}}, "catalog": []}}')
     })
     await client.authenticate()
     disableFetchMocks()

--- a/tests/utils/helpers.ts
+++ b/tests/utils/helpers.ts
@@ -1,8 +1,17 @@
 import sampleSize from 'lodash/sampleSize'
+import { MockResponseInit } from 'jest-fetch-mock'
 
 const defaultCharset = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
 
 export function randomString(size: number): string {
     const samp = sampleSize(defaultCharset, size) as string[]
     return samp.join('')
+}
+
+export function json(body = ''): MockResponseInit {
+    return {
+        body: body,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        init: { headers: { 'Content-Type': 'application/json' } },
+    }
 }


### PR DESCRIPTION
Add `raw` field to `JSONResponse`

`JSONResponse.data` now will be correctly set only in case `Content-Type: application/json` header is set in the response