### PR TITLE
Fix invalid version value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelekomcloud/oms",
-  "version": "0.1.2",
+  "version": "0.1.3-beta.2",
   "description": "Micro SDK for OpenTelekomCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version like `0.0-...` are not `semver`-compatible. Valid `semver` version contains three parts at least