### PR TITLE
Promote `0.1.3-beta.5` to `0.1.3`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelekomcloud/oms",
-  "version": "0.1.3-beta.5",
+  "version": "0.1.3",
   "description": "Micro SDK for OpenTelekomCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version `0.1.3-beta.5` is tested with `ui-cluster-driver-otc`