### PR TITLE
Make headers isomorphic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelekomcloud/oms",
-  "version": "0.1.3",
+  "version": "0.1.5-beta.1",
   "description": "Micro SDK for OpenTelekomCloud",
   "repository": {
     "type": "git",
@@ -59,7 +59,10 @@
     "collectCoverageFrom": [
       "src/**/*.ts"
     ],
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFiles": [
+      "./tests/setupJest.ts"
+    ]
   },
   "scripts": {
     "cov-rename": "mv ./coverage/coverage-final.json ./coverage/coverage-$0.json",
@@ -76,8 +79,8 @@
     "release": "yarn clean && yarn build && webpack --mode production"
   },
   "dependencies": {
+    "cross-fetch": "^3.1.4",
     "is-cidr": "^4.0.2",
-    "isomorphic-fetch": "^3.0.0",
     "lodash": "^4.17.20",
     "query-string": "^6.13.2"
   },

--- a/src/oms/core/http.ts
+++ b/src/oms/core/http.ts
@@ -7,8 +7,7 @@ import isEmpty from 'lodash/isEmpty'
 import { ParsedQuery, stringifyUrl } from 'query-string'
 import { validate } from 'json-schema'
 import { JSONSchema } from './types'
-
-require('isomorphic-fetch')
+import fetch, { Headers } from 'cross-fetch'
 
 export type RequestConfigHandler = (i: RequestOpts) => RequestOpts
 

--- a/src/oms/core/signer.ts
+++ b/src/oms/core/signer.ts
@@ -1,4 +1,5 @@
 import sha256, { hmac } from 'fast-sha256'
+import { Headers } from 'cross-fetch'
 
 export interface CredentialInfo {
     readonly accessKeyId: string,

--- a/src/oms/services/object-storage/swift/v1/accounts.ts
+++ b/src/oms/services/object-storage/swift/v1/accounts.ts
@@ -1,6 +1,7 @@
 import HttpClient from '../../../../core/http'
-import { AccountMetadata, Account, ContainerMetadata } from './types'
+import { Account, AccountMetadata, ContainerMetadata } from './types'
 import { Metadata } from '../../../../core'
+import { Headers } from 'cross-fetch'
 
 const url = ''
 

--- a/src/oms/services/object-storage/swift/v1/container.ts
+++ b/src/oms/services/object-storage/swift/v1/container.ts
@@ -1,6 +1,7 @@
 import HttpClient, { joinURL } from '../../../../core/http'
 import { Metadata } from '../../../../core'
 import { Container, ContainerMetadata, ObjectEntity, ObjectListOpts } from './types'
+import { Headers } from 'cross-fetch'
 
 const url = ''
 

--- a/tests/integration/client.test.ts
+++ b/tests/integration/client.test.ts
@@ -3,18 +3,22 @@ import { authServerUrl, fakeAuthServer, fakeServiceServer, fakeToken } from '../
 import { json, randomString } from '../utils/helpers'
 import Service from '../../src/oms/services/base'
 import HttpClient from '../../src/oms/core/http'
-import { disableFetchMocks, enableFetchMocks } from 'jest-fetch-mock'
+import fetchMock from 'jest-fetch-mock'
 
 beforeAll(() => {
     fakeAuthServer.listen()
     fakeServiceServer.listen()
-    enableFetchMocks()
+    fetchMock.enableMocks()
+})
+
+beforeEach(() => {
+    fetchMock.resetMocks()
 })
 
 afterAll(() => {
     fakeAuthServer.close()
     fakeServiceServer.close()
-    disableFetchMocks()
+    fetchMock.disableMocks()
 })
 
 test.skip('Client: authToken', async () => {

--- a/tests/setupJest.ts
+++ b/tests/setupJest.ts
@@ -1,0 +1,10 @@
+// Thanks to @ctaylo21 at https://github.com/jefflau/jest-fetch-mock/issues/122#issuecomment-542273089
+
+import { GlobalWithFetchMock } from 'jest-fetch-mock';
+
+const customGlobal = global as unknown as GlobalWithFetchMock;
+customGlobal.fetch = require('jest-fetch-mock');
+customGlobal.fetchMock = customGlobal.fetch;
+
+jest.setMock('cross-fetch', fetch);
+fetchMock.dontMock()

--- a/tests/unit/signer.test.ts
+++ b/tests/unit/signer.test.ts
@@ -1,18 +1,18 @@
 import { getSignHeaders } from '../../src/oms'
-
+import { Headers } from 'cross-fetch'
 
 test('aws-signature test', () => {
     const myUrl = new URL('https://iam.eu-de.otc.t-systems.com/v3/projects?name=eu-de_test_dmd')
     const date = new Date('Wed, 21 Oct 2020 11:54:11 GMT')
     const headers = new Headers()
     headers.set('accept', 'application/json')
-    headers.set( 'user-agent', 'OpenTelekomCloud JS/v1.0' )
-    headers.set( 'content-type', 'application/json' )
+    headers.set('user-agent', 'OpenTelekomCloud JS/v1.0')
+    headers.set('content-type', 'application/json')
     const signedHeaderGet = getSignHeaders(
         {
             accessKeyId: 'AKIDEXAMPLE',
             secretAccessKey: 'BYBYIiF3WUZGlorXmcTEDtNjB40JTibEXAMPLE',
-            regionName: ''
+            regionName: '',
         },
         {
             method: 'GET',
@@ -20,8 +20,8 @@ test('aws-signature test', () => {
             serviceName: '',
             headers: headers,
         },
-        date
-    );
+        date,
+    )
     expect(signedHeaderGet.Authorization).toBe(
         'SDK-HMAC-SHA256 Credential=AKIDEXAMPLE/20201021///sdk_request,' +
         ' SignedHeaders=accept;content-type;host;user-agent;x-sdk-date,' +

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,13 +714,13 @@ __metadata:
     babel-register: ^6.26.0
     browserify: ^16.5.2
     codecov: ^3.7.2
+    cross-fetch: ^3.1.4
     eslint: ^7.10.0
     eslint-import-resolver-typescript: ^2.3.0
     eslint-plugin-import: ^2.22.1
     eslint-plugin-node: ^11.1.0
     fast-sha256: ^1.3.0
     is-cidr: ^4.0.2
-    isomorphic-fetch: ^3.0.0
     jest: ^26.6.3
     jest-fetch-mock: ^3.0.3
     jsonschema: ^1.2.7
@@ -3297,7 +3297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.0.4":
+"cross-fetch@npm:^3.0.4, cross-fetch@npm:^3.1.4":
   version: 3.1.4
   resolution: "cross-fetch@npm:3.1.4"
   dependencies:
@@ -5784,16 +5784,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"isomorphic-fetch@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "isomorphic-fetch@npm:3.0.0"
-  dependencies:
-    node-fetch: ^2.6.1
-    whatwg-fetch: ^3.4.1
-  checksum: e5ab79a56ce5af6ddd21265f59312ad9a4bc5a72cebc98b54797b42cb30441d5c5f8d17c5cd84a99e18101c8af6f90c081ecb8d12fd79e332be1778d58486d75
-  languageName: node
-  linkType: hard
-
 "isstream@npm:~0.1.2":
   version: 0.1.2
   resolution: "isstream@npm:0.1.2"
@@ -7293,7 +7283,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.1, node-fetch@npm:^2.2.0, node-fetch@npm:^2.6.1":
+"node-fetch@npm:2.6.1, node-fetch@npm:^2.2.0":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
   checksum: 91075bedd57879117e310fbcc36983ad5d699e522edb1ebcdc4ee5294c982843982652925c3532729fdc86b2d64a8a827797a745f332040d91823c8752ee4d7c
@@ -10526,13 +10516,6 @@ webpack@webpack-4:
   dependencies:
     iconv-lite: 0.4.24
   checksum: 5be4efe111dce29ddee3448d3915477fcc3b28f991d9cf1300b4e50d6d189010d47bca2f51140a844cf9b726e8f066f4aee72a04d687bfe4f2ee2767b2f5b1e6
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:^3.4.1":
-  version: 3.6.2
-  resolution: "whatwg-fetch@npm:3.6.2"
-  checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Move to `cross-fetch`

Get rid of `require` statement

Import `Headers` from `cross-fetch`

Part of #86 

### Acceptance
```
Cleaned!
 PASS  tests/unit/service.test.ts
 PASS  tests/unit/signer.test.ts
 PASS  tests/unit/types.test.ts
 PASS  tests/unit/http.test.ts

Test Suites: 4 passed, 4 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        3.249 s, estimated 5 s
Ran all test suites matching /.\/tests\/unit/i.
 PASS  tests/integration/client.test.ts
  ✓ Client: register service (1 ms)
  ✓ Client: no auth opts (5 ms)
  ✓ Client: abs URL (2 ms)
  ✓ Client: abs URL with base (1 ms)
  ✓ Client: merge handlers
  ✓ Client: ak/sk auth; request headers (9 ms)
  ○ skipped Client: authToken
  ○ skipped Client: authAKSK
  ○ skipped Client: get not registered service
  ○ skipped Client: no ak/sk opts
  ○ skipped Client: ak/sk opts

Test Suites: 1 passed, 1 total
Tests:       5 skipped, 6 passed, 11 total
Snapshots:   0 total
Time:        1.447 s, estimated 5 s
Ran all test suites matching /.\/tests\/integration/i.
 PASS  tests/functional/services/identity.test.ts
 PASS  tests/functional/client.test.ts (6.194 s)
 PASS  tests/functional/services/compute.test.ts (8.168 s)
 PASS  tests/functional/services/swift.test.ts (8.928 s)
 PASS  tests/functional/services/image.test.ts (40.03 s)
  ● Console

    console.log
      Loaded 7 pages

      at Pager.<anonymous> (src/oms/services/base.ts:87:17)

    console.log
      Loaded 7 pages

      at Pager.<anonymous> (src/oms/services/base.ts:87:17)

 PASS  tests/functional/services/networkv1.test.ts (51.4 s)

Test Suites: 6 passed, 6 total
Tests:       6 skipped, 36 passed, 42 total
Snapshots:   0 total
Time:        51.726 s, estimated 53 s
Ran all test suites matching /.\/tests\/functional/i.
coverage files in coverage merged into coverage/merged-coverage.json

```